### PR TITLE
Tracks have persistent IDs

### DIFF
--- a/src/components/Playlist.js
+++ b/src/components/Playlist.js
@@ -34,7 +34,7 @@ const Playlist = (props) => {
     // the variable 'track' as props. Go look it up!
     return (
       <Track
-        key={i}
+        key={track.id}
         {...track}
       />
     );


### PR DESCRIPTION
This is important for implementations where the favorite-d status is being stored in `state` on the `Track` component.

In that situation, when a track is moved to the top of the playlist, the index-based keys code would cause React to believe that the track which is _now_ in the position of the track that was moved to the top of the list, is the one which still has the favorite status.

(Basically, if you don't do this then "favorite" status is more associated with a particular index in the track list, rather than a particular track.)